### PR TITLE
[FIX] TileCondition functionality

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/model/queue/QueueTask.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/queue/QueueTask.kt
@@ -102,8 +102,8 @@ data class QueueTask(val ctx: Any, val priority: TaskPriority) : Continuation<Un
      * of [Pawn] and that the height of the [tile] and [Pawn.tile] must be equal,
      * as well as the x and z coordinates.
      */
-    suspend fun waitTile(tile: Tile): Unit = suspendCoroutine {
-        nextStep = SuspendableStep(TileCondition((ctx as Pawn).tile, tile), it)
+    suspend fun waitTile(tile: Tile, pawn: Pawn = ctx as Pawn): Unit = suspendCoroutine {
+        nextStep = SuspendableStep(TileCondition(pawn, tile), it)
     }
 
     /**

--- a/game/src/main/kotlin/gg/rsmod/game/model/queue/coroutine/SuspendableCondition.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/queue/coroutine/SuspendableCondition.kt
@@ -2,6 +2,7 @@ package gg.rsmod.game.model.queue.coroutine
 
 import com.google.common.base.MoreObjects
 import gg.rsmod.game.model.Tile
+import gg.rsmod.game.model.entity.Pawn
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -33,23 +34,23 @@ class WaitCondition(cycles: Int) : SuspendableCondition() {
 }
 
 /**
- * A [SuspendableCondition] that waits for [src] to possess the exact same
+ * A [SuspendableCondition] that waits for [pawn] to possess the exact same
  * coordinates as [dst] before permitting the coroutine to continue its logic.
  *
- * Note that the [src] and [dst] can't be the same coordinates if their height
+ * Note that the [pawn] and [dst] can't be the same coordinates if their height
  * does not match as well as their x and z coordinates.
  *
- * @param src
+ * @param pawn
  * The tile that must reach [dst] before the condition returns true.
  *
  * @param dst
  * The tile that must be reached by [dst].
  */
-class TileCondition(private val src: Tile, private val dst: Tile) : SuspendableCondition() {
+class TileCondition(private val pawn: Pawn, private val dst: Tile) : SuspendableCondition() {
 
-    override fun resume(): Boolean = src.sameAs(dst)
+    override fun resume(): Boolean = pawn.tile.sameAs(dst)
 
-    override fun toString(): String = MoreObjects.toStringHelper(this).add("src", src).add("dst", dst).toString()
+    override fun toString(): String = MoreObjects.toStringHelper(this).add("pawn", pawn).add("dst", dst).toString()
 }
 
 /**


### PR DESCRIPTION
Problem: `TileCondition` (used by `QueueTask.waitTile(Tile)` does not work correctly.

Symptom: `Tile` properties that are used in `Tile.sameAs(Tile)` are `val` thus cannot be changed. When a tile was passed to `TileCondition` as `src`. It seems as though the intention was for `src` to update as a reference the properties update, but the properties will never update, thus rendering `TileCondition` useless.

Solution: `TileCondition` now takes `Pawn` and `Tile`, and since `Pawn.tile` is a `var` it means that it changes as `Pawn.tile` changes, and it allows `TileCondition` to work as expected. `QueueTask.waitTile(tile: Tile)` has been changed to `QueueTask.waitTile(tile: Tile, pawn: Pawn = ctx as Pawn)`

## What has been done?

## Proposed Changes

  -
  -
  -